### PR TITLE
Stub response passed to `prepareStream`’s callback to avoid a `TypeError`

### DIFF
--- a/homebridge/camera-source.ts
+++ b/homebridge/camera-source.ts
@@ -64,8 +64,42 @@ export class CameraSource {
 
   handleCloseConnection(connectionID: any) {}
 
-  prepareStream(request: any, callback: (response: any) => void) {
-    callback(new Error('Not implemented'))
+  prepareStream(
+    request: any,
+    callback: (response: {
+      address: {
+        type: 'v4' | 'v6'
+        ipAddress?: string
+      }
+      video: {
+        port?: number
+        ssrc?: number
+        proxy_pt?: string
+        proxy_server_address?: string
+        proxy_server_rtp?: string
+        proxy_server_rtcp?: string
+        srtp_key?: string
+        srtp_salt?: string
+      }
+      audio: {
+        port?: number
+        ssrc?: number
+        proxy_pt?: string
+        proxy_server_address?: string
+        proxy_server_rtp?: string
+        proxy_server_rtcp?: string
+        srtp_key?: string
+        srtp_salt?: string
+      }
+    }) => void
+  ) {
+    callback({
+      address: {
+        type: 'v4'
+      },
+      video: {},
+      audio: {}
+    })
   }
 
   handleStreamRequest(request: any) {}


### PR DESCRIPTION
Attempting to fix https://github.com/dgreif/ring-alarm/issues/35#issuecomment-504610023

Disclaimer: I haven’t tested this locally, because I don’t have a Ring camera set up.

I inspected the call stack provided by @ifeign, and the cause of the `TypeError` appears to be [the attempt to read `response.address.type` on line 658](https://github.com/KhaosT/HAP-NodeJS/blob/a42102f5db0388b67f28974ca5fa489933ca1be6/lib/StreamController.js#L658) in HAP-NodeJS’ `StreamController`.

Because `ring-alarm-homebrige` [currently passes an `Error`](https://github.com/smockle/ring-alarm/blob/eb80eb3165b5412e689d078f2e417eb449bd6891/homebridge/camera-source.ts#L68) as `response`, and `Error` does not have a `address` property, attempting to read `type` from the non-existent `address` property results in `Cannot read property 'type' of undefined`.